### PR TITLE
Feature/#73: 카테고리 목록 드래그앤드랍 기능 구현

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,17 +13,6 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="test()">
-        <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-02-07T08:23:00.606592900Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=R3CX20PCWHP" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/main/java/com/example/yeongkkuel/presentation/base/MainActivity.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/base/MainActivity.kt
@@ -350,9 +350,10 @@ class MainActivity : AppCompatActivity(), BotSheetListener {
 
         // iv_hamberger 클릭 리스너 추가
         binding.ivHamberger.setOnClickListener {
+            categoryViewModel.updateCategoryOrderLocally(botSheetViewModel.getCategoryList()) // 현재 카테고리 목록을 ViewModel에 업데이트
             navController.navigate(R.id.categoryManageFragment)
             val bottomSheetBehavior = BottomSheetBehavior.from(binding.clItemBotSheet)
-            bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED // BottomSheet 닫기
+            bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
         }
     }
 

--- a/app/src/main/java/com/example/yeongkkuel/presentation/botsheet/BotSheetViewModel.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/botsheet/BotSheetViewModel.kt
@@ -311,7 +311,7 @@ class BotSheetViewModel : ViewModel() {
             )
         }
         Log.d("BotSheetViewModel", "getCategoryList() 반환: $categoryList")
-        return categoryList
+        return _categoryList.value.orEmpty()
     }
 
     fun addExpenseHistory(history: BotSheetUiState.Spending.History) {

--- a/app/src/main/java/com/example/yeongkkuel/presentation/home/category/CategoryManageFragment.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/home/category/CategoryManageFragment.kt
@@ -4,13 +4,16 @@ import android.graphics.Rect
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.yeongkkuel.R
@@ -18,18 +21,17 @@ import com.example.yeongkkuel.databinding.FragmentCategoryManageBinding
 import com.example.yeongkkuel.presentation.botsheet.BotSheetViewModel
 import com.example.yeongkkuel.presentation.home.category.adapter.CategoryAdapter
 import com.example.yeongkkuel.presentation.home.category.data.Category
+import kotlinx.coroutines.launch
 
 class CategoryManageFragment : Fragment() {
 
     private var _binding: FragmentCategoryManageBinding? = null
     private val binding get() = _binding!!
-    private val viewModel: CategoryViewModel by activityViewModels() // ViewModel 연결
+    private val viewModel: CategoryViewModel by activityViewModels()
     private val botSheetViewModel: BotSheetViewModel by activityViewModels()
-    private val categoryAdapter by lazy {
-        CategoryAdapter(onCategoryClick = { category ->
-            navigateToCategoryDetail(category) // 클릭 시 상세 페이지로 이동
-        })
-    }
+
+    private lateinit var categoryAdapter: CategoryAdapter
+    private lateinit var itemTouchHelper: ItemTouchHelper
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -39,37 +41,68 @@ class CategoryManageFragment : Fragment() {
         return binding.root
     }
 
-    override fun onResume() {
-        super.onResume()
-        viewModel.fetchCategories() // ✅ 프래그먼트가 다시 활성화될 때 최신 데이터 불러오기
-
-        Handler(Looper.getMainLooper()).postDelayed({
-            viewModel.fetchCategories() // ✅ 한 번 더 호출하여 UI 강제 갱신
-        }, 500) // 0.5초 후 한 번 더 호출
-    }
-
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        // categoryAdapter 초기화
+        categoryAdapter = CategoryAdapter(
+            onCategoryClick = { category ->
+                navigateToCategoryDetail(category)
+            },
+            onStartDrag = { viewHolder ->
+                itemTouchHelper.startDrag(viewHolder)
+            }
+        )
+
+        // ✅ itemTouchHelper 초기화
+        itemTouchHelper = ItemTouchHelper(object : ItemTouchHelper.SimpleCallback(
+            ItemTouchHelper.UP or ItemTouchHelper.DOWN, 0
+        ) {
+            override fun onMove(
+                recyclerView: RecyclerView,
+                viewHolder: RecyclerView.ViewHolder,
+                target: RecyclerView.ViewHolder
+            ): Boolean {
+                val fromPosition = viewHolder.bindingAdapterPosition
+                val toPosition = target.bindingAdapterPosition
+                Log.d("CategoryManageFragment", "📌 아이템 이동: $fromPosition -> $toPosition")
+
+                categoryAdapter.moveItem(fromPosition, toPosition) // UI 순서 변경
+                return true
+            }
+
+            override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
+                // 스와이프 기능 비활성화
+            }
+
+            override fun clearView(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder) {
+                super.clearView(recyclerView, viewHolder)
+
+                val updatedList = categoryAdapter.getCategoryList()
+                // ViewModel에 변경된 카테고리 순서 반영
+                viewModel.updateCategoryOrderLocally(updatedList)
+
+                // 변경된 리스트를 RecyclerView에 반영
+                categoryAdapter.submitList(updatedList)
+            }
+        })
+
         // RecyclerView 설정
         setupRecyclerView()
+        itemTouchHelper.attachToRecyclerView(binding.rvCategoryList) // RecyclerView와 연결
 
-        // ViewModel 데이터 관찰
+        // 데이터 가져오기 및 UI 업데이트
         observeViewModel()
-
-        // 서버에서 카테고리 데이터 가져오기
         fetchCategoriesFromServer()
+
+        Log.d("CategoryManageFragment", "✅ onViewCreated() 완료")
 
         // 추가 버튼 클릭 이벤트
         binding.tvCategoryAdd.setOnClickListener {
-            val categoryCount = viewModel.categories.value?.size ?: 0 // 카테고리 개수 가져오기
-
+            val categoryCount = viewModel.categories.value?.size ?: 0
             if (categoryCount >= 6) {
-                // 카테고리가 6개 이상일 때 팝업 띄우기
                 showLimitReachedPopup()
             } else {
-                // 카테고리가 6개 미만일 때 카테고리 추가 화면으로 이동
                 findNavController().navigate(R.id.action_categoryManageFragment_to_categoryAddFragment)
             }
         }
@@ -80,28 +113,39 @@ class CategoryManageFragment : Fragment() {
         }
     }
 
-    private fun fetchCategoriesFromServer() {
-        viewModel.fetchCategories() // 서버에서 데이터 가져오기
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.fetchCategories()
+
+        Handler(Looper.getMainLooper()).postDelayed({
+            viewModel.fetchCategories()
+        }, 500)
     }
 
     private fun observeViewModel() {
-        // 카테고리 관리 페이지 업데이트
-        viewModel.categories.observe(viewLifecycleOwner) { categories ->
-            categoryAdapter.submitList(categories) // 데이터를 어댑터에 반영 - 즉시 UI 업데이트
-            categoryAdapter.notifyDataSetChanged() // 강제로 RecylcerView 갱신
-        }
+        viewLifecycleOwner.lifecycleScope.launch {
+            // 카테고리 데이터 관찰
+            viewModel.categories.observe(viewLifecycleOwner) { categories ->
+                if (categories.isNotEmpty()) {
+                    categoryAdapter.submitList(categories)
+                }
+            }
 
-        // 바텀시트 데이터 관찰하여 삭제 후 즉시 반영
-        botSheetViewModel.categoryList.observe(viewLifecycleOwner) { categories ->
-            categoryAdapter.submitList(categories) // 바텀시트 리스트도 업데이트
-            categoryAdapter.notifyDataSetChanged() // RecyclerView 강제 갱신
-        }
+            // 바텀시트 데이터 관찰
+            botSheetViewModel.categoryList.observe(viewLifecycleOwner) { categories ->
+                if (categories.isNotEmpty()) {
+                    categoryAdapter.submitList(categories)
+                    categoryAdapter.notifyDataSetChanged()
+                }
+            }
 
-        // 에러 메시지 관찰
-        viewModel.errorMessage.observe(viewLifecycleOwner) { errorMessage ->
-            errorMessage?.let {
-                // 에러 메시지 표시 (Toast 또는 다른 방식으로 처리 가능)
-                android.widget.Toast.makeText(requireContext(), it, android.widget.Toast.LENGTH_SHORT).show()
+            // 에러 메시지 관찰
+            viewModel.errorMessage.observe(viewLifecycleOwner) { errorMessage ->
+                errorMessage?.let {
+                    Log.e("CategoryManageFragment", "❌ ViewModel 에러 발생: $it") // ✅ 추가 로그
+                    android.widget.Toast.makeText(requireContext(), it, android.widget.Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }
@@ -111,7 +155,6 @@ class CategoryManageFragment : Fragment() {
             layoutManager = LinearLayoutManager(requireContext())
             adapter = categoryAdapter
 
-            // 카테고리 아이템 간격 추가
             addItemDecoration(object : RecyclerView.ItemDecoration() {
                 override fun getItemOffsets(
                     outRect: Rect,
@@ -119,17 +162,21 @@ class CategoryManageFragment : Fragment() {
                     parent: RecyclerView,
                     state: RecyclerView.State
                 ) {
-                    outRect.top = 16 // 각 아이템의 위쪽에 16dp 간격
-                    outRect.bottom = 16 // 각 아이템의 아래쪽에 16dp 간격
+                    outRect.top = 16
+                    outRect.bottom = 16
                 }
             })
         }
     }
 
+    private fun fetchCategoriesFromServer() {
+        viewModel.fetchCategories()
+    }
+
     private fun navigateToCategoryDetail(category: Category) {
         val bundle = Bundle().apply {
             putString("categoryName", category.name)
-            putInt("categoryColor", category.color.id) // Colors의 id를 Int로 전달
+            putInt("categoryColor", category.color.id)
         }
         findNavController().navigate(R.id.action_categoryManageFragment_to_categoryDetailFragment, bundle)
     }

--- a/app/src/main/java/com/example/yeongkkuel/presentation/home/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/home/category/CategoryViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.yeongkkuel.presentation.home.category
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -34,26 +35,24 @@ class CategoryViewModel : ViewModel() {
         viewModelScope.launch {
             try {
                 val response = RetrofitClient.categoryApiService.getCategories()
-
-                println("Response Body: ${response.result}") // Response Body 확인 로그
-
-                if (response.isSuccess) { // 커스텀 Response의 isSuccess 확인
-                    // TODO - 방어 로직 추가
+                if (response.isSuccess) {
                     val categoryListResponse = response.result
-                    _categories.value = categoryListResponse.categoryList.map { it.toCategory() } // result를 로컬 데이터로 변환
+                    _categories.postValue(categoryListResponse.categoryList.map { it.toCategory() }) // ✅ postValue()로 변경
 
-                    // ✅ UI 강제 갱신 (값이 동일해도 LiveData가 변경되도록)
-                    _categories.value = _categories.value
-                } else {
-                    _errorMessage.value = "Failed to fetch categories: ${response.message}" // 서버 메시지 활용
+                    Log.d("CategoryViewModel", "✅ LiveData postValue() 업데이트 완료!")
                 }
-            } catch (e: HttpException) {
-                _errorMessage.value = "Server error: ${e.message()}"
             } catch (e: Exception) {
-                _errorMessage.value = "Error: ${e.message}"
+                _errorMessage.postValue("Error: ${e.message}") // ✅ postValue() 사용
             }
         }
     }
+
+
+    fun updateCategoryOrderLocally(updatedList: List<Category>) {
+        _categories.value = updatedList // 서버 요청 없이 UI만 업데이트 -  변경된 리스트를 LiveData에 반영
+        Log.d("CategoryViewModel", "✅ 카테고리 순서 로컬 업데이트 완료")
+    }
+
 
     // 카테고리 추가 (서버와 동기화)
     fun addCategory(category: Category): Boolean {
@@ -135,35 +134,6 @@ class CategoryViewModel : ViewModel() {
             }
         }
     }
-
-
-//    // 카테고리 수정 (서버와 동기화)
-//    fun updateCategory(originalName: String, updatedCategory: Category) {
-//        val categoryToUpdate = _categories.value.orEmpty().find { it.name == originalName }
-//        if (categoryToUpdate != null) {
-//            viewModelScope.launch {
-//                try {
-//                    val request = updatedCategory.toRequest() // 로컬 데이터를 요청 데이터로 변환
-//                    val response = RetrofitClient.yeongkkuelService.updateCategory(categoryToUpdate.id, request)
-//
-//                    if (response.isSuccess) { // 커스텀 Response의 isSuccess 확인
-//                        fetchCategories() // 수정 후 최신 데이터 다시 불러오기
-//
-//                        val updatedList = _categories.value?.toMutableList() ?: mutableListOf()
-//                        val index = updatedList.indexOfFirst { it.name == originalName }
-//                        if (index != -1) {
-//                            updatedList[index] = updatedCategory
-//                            _categories.value = updatedList
-//                        }
-//                    } else {
-//                        _errorMessage.value = "Failed to update category: ${response.message}"
-//                    }
-//                } catch (e: Exception) {
-//                    _errorMessage.value = "Error: ${e.message}"
-//                }
-//            }
-//        }
-//    }
 
     // 카테고리 목록 비어 있는지 확인
     fun isCategoryListEmpty(): Boolean {

--- a/app/src/main/java/com/example/yeongkkuel/presentation/home/category/adapter/CategoryAdapter.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/home/category/adapter/CategoryAdapter.kt
@@ -1,5 +1,6 @@
 package com.example.yeongkkuel.presentation.home.category.adapter
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
@@ -10,8 +11,9 @@ import com.example.yeongkkuel.databinding.ItemCategoryBinding
 import com.example.yeongkkuel.presentation.home.category.data.Category
 
 class CategoryAdapter(
-    private val onCategoryClick: (Category) -> Unit // 클릭 이벤트 전달
-) : ListAdapter<Category, CategoryAdapter.CategoryViewHolder>(CategoryDiffCallback()) {
+    private val onCategoryClick: (Category) -> Unit,
+    private val onStartDrag: (RecyclerView.ViewHolder) -> Unit // 드래그 시작 콜백 추가
+) : ListAdapter<Category, CategoryAdapter.CategoryViewHolder>(CategoryDiffCallback()) { // ListAdapter로 변경
 
     inner class CategoryViewHolder(private val binding: ItemCategoryBinding) :
         RecyclerView.ViewHolder(binding.root) {
@@ -27,6 +29,12 @@ class CategoryAdapter(
             root.setOnClickListener {
                 onCategoryClick(item) // 클릭 이벤트 실행
             }
+
+            // 길게 눌렀을 때 드래그 시작
+            root.setOnLongClickListener {
+                onStartDrag(this@CategoryViewHolder) // 드래그 시작
+                true
+            }
         }
     }
 
@@ -40,9 +48,26 @@ class CategoryAdapter(
     }
 
     override fun onBindViewHolder(holder: CategoryViewHolder, position: Int) {
-        holder.bind(getItem(position)) // 데이터 바인딩
+        val category = getItem(position) // `getItem(position)`으로 아이템 가져오기
+        holder.bind(category)
     }
 
+    override fun getItemCount(): Int = currentList.size // ListAdapter에서는 currentList 사용
+
+    // 드래그하여 순서 변경하는 함수
+    fun moveItem(fromPosition: Int, toPosition: Int) {
+        val currentList = currentList.toMutableList() // 현재 리스트를 MutableList로 변환
+        val movedItem = currentList.removeAt(fromPosition)
+        currentList.add(toPosition, movedItem)
+
+        // 데이터 변경 후 submitList()로 RecyclerView 갱신
+        submitList(currentList)
+    }
+
+    // 현재 리스트 반환
+    fun getCategoryList(): List<Category> = currentList.toList()
+
+    // DiffUtil을 이용하여 변경 사항만 갱신하도록 처리
     class CategoryDiffCallback : DiffUtil.ItemCallback<Category>() {
         override fun areItemsTheSame(oldItem: Category, newItem: Category): Boolean {
             return oldItem.id == newItem.id // ID로 고유성 판단

--- a/app/src/main/res/layout/fragment_expense_entry.xml
+++ b/app/src/main/res/layout/fragment_expense_entry.xml
@@ -218,6 +218,27 @@
                     app:layout_constraintBottom_toBottomOf="parent" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
+            <!-- 지출 내역 - 지출 내용 보기-->
+            <TextView
+                android:id="@+id/tv_detail_input_view"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="10dp"
+                android:background="@drawable/bg_edit_text"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="start|center_vertical"
+                android:paddingHorizontal="10dp"
+                android:paddingVertical="5dp"
+                android:layout_marginStart="13dp"
+                android:layout_marginTop="35dp"
+                android:textColor="@color/black"
+                android:textSize="15sp"
+                android:visibility="gone"
+                app:layout_constraintStart_toEndOf="@id/tv_expense_detail"
+                app:layout_constraintTop_toBottomOf="@id/tv_category_input"
+                app:layout_constraintBottom_toBottomOf="@id/tv_expense_detail"/>
+
 
             <!--  지출액 -->
             <TextView
@@ -258,6 +279,36 @@
                 android:textSize="15sp"
                 app:layout_constraintStart_toEndOf="@id/et_amount_input"
                 app:layout_constraintBaseline_toBaselineOf="@id/et_amount_input" />
+
+            <!-- 지출 내역 - 지출액 보기-->
+            <TextView
+                android:id="@+id/tv_amount_input_view"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_edit_text"
+                android:textColor="@color/black"
+                android:textSize="15sp"
+                android:layout_marginStart="34dp"
+                android:layout_marginTop="35dp"
+                android:paddingHorizontal="10dp"
+                android:paddingVertical="5dp"
+                android:visibility="gone"
+                app:layout_constraintStart_toEndOf="@id/tv_expense_amount"
+                app:layout_constraintTop_toBottomOf="@id/cl_detail_input"/>
+
+            <TextView
+                android:id="@+id/tv_currency_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:text="원"
+                android:textColor="@color/black"
+                android:textSize="15sp"
+                android:visibility="gone"
+                app:layout_constraintStart_toEndOf="@id/tv_amount_input_view"
+                app:layout_constraintBaseline_toBaselineOf="@id/et_amount_input" />
+
+
 
             <!-- 무지출 체크 -->
             <androidx.constraintlayout.widget.ConstraintLayout

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.2.2"
+agp = "8.6.0"
 flexiblestepRangeslider = "1.0.0"
 kotlin = "1.9.22"
 coreKtx = "1.15.0"


### PR DESCRIPTION
## *📌 Issue*
- closed #73 
<!-- closed를 붙이면 해당 이슈가 PR과 함께 자동으로 close -->

## *⛳️ Work Description*
- 카테고리 목록 관리 페이지 드래그앤드랍 기능 구현

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/19ca7c19-09f3-4dbc-bba7-db0894420524

## *📢 To Reviewers*
- 동원님 바텀시트 카테고리와 카테고리 목록 페이지의 카테고리 순서 동기화 연결 이어서 마저 부탁드립니다
- 그리고 빌드 했을 때 지출 탭을 누르지 않으면 홈 탭에서 바텀시트가 서버와 연결이 되지 않는 이슈가 아직 해결 중인 상태인데, 혹시 방법 아신다면 공유해주시면 감사하겠습니다..

<!-- PR 제목 형식: [FEATURE/#이슈번호] 작업 주제 -->
