### PR TITLE
Feature/#65 지출 디테일

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,6 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,10 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DiscordProjectSettings">
     <option name="show" value="ASK" />
     <option name="description" value="" />
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />
   <component name="VisualizationToolProject">
     <option name="state">
       <ProjectState>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,8 +114,4 @@ dependencies {
 
     // JwtDecode
     implementation(libs.jwtdecode)
-
-    //rxjava
-    implementation("io.reactivex.rxjava3:rxjava:3.0.13")
-    implementation("io.reactivex.rxjava3:rxandroid:3.0.0")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,4 +114,8 @@ dependencies {
 
     // JwtDecode
     implementation(libs.jwtdecode)
+
+    //rxjava
+    implementation("io.reactivex.rxjava3:rxjava:3.0.13")
+    implementation("io.reactivex.rxjava3:rxandroid:3.0.0")
 }

--- a/app/src/main/java/com/example/yeongkkuel/network/response/expenditure/WeekExpendituresAverage.kt
+++ b/app/src/main/java/com/example/yeongkkuel/network/response/expenditure/WeekExpendituresAverage.kt
@@ -3,12 +3,12 @@ package com.example.yeongkkuel.network.response.expenditure
 import com.google.gson.annotations.SerializedName
 
 data class WeekExpendituresAverage(
-    @SerializedName("age") val age: String,
-    @SerializedName("job") val job: String,
-    @SerializedName("topPercent") val topPercent: Int,
-    @SerializedName("averageExpenditure") val averageExpenditure: Int,
+    @SerializedName("age") val age: String?,
+    @SerializedName("job") val job: String?,
+    @SerializedName("topPercent") val topPercent: Int?,
+    @SerializedName("averageExpenditure") val averageExpenditure: Int?,
     @SerializedName("myAverageExpenditure") val myAverageExpenditure: Int,
-    @SerializedName("lastWeekExpenditure") val lastWeekExpenditure: Int,
+    @SerializedName("lastWeekExpenditure") val lastWeekExpenditure: Int?,
     @SerializedName("thisWeekExpenditure") val thisWeekExpenditure: Int,
     @SerializedName("categories") val categories: List<Category>
 ) {

--- a/app/src/main/java/com/example/yeongkkuel/network/service/StatService.kt
+++ b/app/src/main/java/com/example/yeongkkuel/network/service/StatService.kt
@@ -14,32 +14,32 @@ import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface StatService {
-    @GET("/api/expenditures/day")
+    @GET("/api/expense/day")
     suspend fun getExpendituresDay(
     ): retrofit2.Response<Response<DayExpenditureResponse>>
 
-    @GET("/api/expenditures/week/expenses")
+    @GET("/api/expense/week/expenses")
     suspend fun getExpendituresWeekExpenses(
     ): Response<WeekExpenditureExpensesResponse>
 
-    @GET("/api/expenditures/week/average")
+    @GET("/api/expense/week/average")
     suspend fun getExpendituresWeekAverage(
     ): Response<WeekExpendituresAverage>
 
-    @GET("/api/expenditures/month/{year}/{month}")
+    @GET("/api/expense/month/{year}/{month}")
     suspend fun getExpendituresMonthCalendar(
         @Path("year") year: Int,
         @Path("month") month: Int
     ): Response<MonthExpendituresCalendar>
 
-    @GET("/api/expenditures/{year}/{month}/{day}")
+    @GET("/api/expense/{year}/{month}/{day}")
     suspend fun getExpendituresMonthCategory(
         @Path("year") year: Int,
         @Path("month") month: Int,
         @Path("day") day: Int,
     ): Response<MonthExpendituresCategory>
 
-    @POST("/api/expenditures/target")
+    @POST("/api/expense/target")
     suspend fun postExpendituresTarget(
         @Body request: ExpenditureTargetRequest
     )

--- a/app/src/main/java/com/example/yeongkkuel/presentation/base/MainActivity.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/base/MainActivity.kt
@@ -369,7 +369,7 @@ class MainActivity : AppCompatActivity(), BotSheetListener {
     }
 
     private fun onBind(uiState: BotSheetUiState) = with(binding) {
-
+        Log.e("histories1", uiState.spendingList.map { it.history }.toString())
         botSheetCategoryListAdapter.submitList(uiState.spendingList)
 
         val isEmpty = uiState.spendingList.isEmpty()

--- a/app/src/main/java/com/example/yeongkkuel/presentation/base/MainActivity.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/base/MainActivity.kt
@@ -75,9 +75,9 @@ class MainActivity : AppCompatActivity(), BotSheetListener {
         }
 
         // 스플래시 화면 종료 조건: 데이터가 로드되지 않았다면 계속 유지
-        splashScreen.setKeepOnScreenCondition {
-            !isDataLoaded()  // 데이터가 아직 로드되지 않았다면 true를 반환해서 스플래시 유지
-        }
+//        splashScreen.setKeepOnScreenCondition {
+//            !isDataLoaded()  // 데이터가 아직 로드되지 않았다면 true를 반환해서 스플래시 유지
+//        }
 
         setupHamburgerClickListener() // 카테고리 더보기 기능 추가
 

--- a/app/src/main/java/com/example/yeongkkuel/presentation/botsheet/BotSheetCategoryListAdapter.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/botsheet/BotSheetCategoryListAdapter.kt
@@ -1,6 +1,7 @@
 package com.example.yeongkkuel.presentation.botsheet
 
 import android.content.res.ColorStateList
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
@@ -35,6 +36,8 @@ class BotSheetCategoryListAdapter(
                 hist.name.isBlank() && hist.price == 0
             }
 
+            Log.e("histories2", originalHistories.toString())
+
             // onBind() 안에서 새로 Adapter 생성
             val localHistoryListAdapter = BotSheetHistoryListAdapter { selectedHistory ->
                 botSheetListener.navigateToExpenseView(
@@ -61,9 +64,11 @@ class BotSheetCategoryListAdapter(
             tvCategory.text = item.kind.name
             val context = root.context
             tvCategory.setTextColor(ContextCompat.getColor(context, categoryColor))
-            ivBtnAdd.backgroundTintList = ColorStateList.valueOf(ContextCompat.getColor(context, categoryColor))
+            ivBtnAdd.backgroundTintList =
+                ColorStateList.valueOf(ContextCompat.getColor(context, categoryColor))
             ivBtnAdd.setImageResource(R.drawable.ic_plus_default)
-            ivBtnAdd.imageTintList = ColorStateList.valueOf(ContextCompat.getColor(context, categoryColor))
+            ivBtnAdd.imageTintList =
+                ColorStateList.valueOf(ContextCompat.getColor(context, categoryColor))
 
             // 카테고리 추가 버튼 클릭 리스너
             ivBtnAdd.setOnClickListener {
@@ -124,6 +129,13 @@ class SpendingCategoryListDiffUtil : DiffUtil.ItemCallback<BotSheetUiState.Spend
         oldItem: BotSheetUiState.Spending,
         newItem: BotSheetUiState.Spending
     ): Boolean {
-        return oldItem.kind == newItem.kind && oldItem.color == newItem.color
+        return oldItem.kind == newItem.kind &&
+                oldItem.color == newItem.color &&
+                oldItem.plusIconResId == newItem.plusIconResId &&
+                oldItem.history.size == newItem.history.size &&
+                oldItem.history.zip(newItem.history).all { (old, new) ->
+                    old == new
+                }
     }
+
 }

--- a/app/src/main/java/com/example/yeongkkuel/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/home/HomeFragment.kt
@@ -82,8 +82,6 @@ class HomeFragment : Fragment() {
 
         navController = Navigation.findNavController(view)
 
-        botSheetViewModel.getSpendingList()
-
         (activity as? MainActivity)?.resetBottomSheetState()
 
         // 홈 탭에 진입할 때 바텀시트 상태(피크 높이)를 재설정

--- a/app/src/main/java/com/example/yeongkkuel/presentation/stat/StatAnimationListener.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/stat/StatAnimationListener.kt
@@ -1,0 +1,5 @@
+package com.example.yeongkkuel.presentation.stat
+
+interface StatAnimationListener {
+    fun animate()
+}

--- a/app/src/main/java/com/example/yeongkkuel/presentation/stat/StatFragment.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/stat/StatFragment.kt
@@ -35,7 +35,8 @@ class StatFragment : Fragment(), ViewPagerTouchListener {
         StatViewPagerAdapter(
             fragment = this@StatFragment,
             weeklyViewModel = weeklyViewModel,
-            monthlyViewModel = monthlyViewModel)
+            monthlyViewModel = monthlyViewModel
+        )
     }
 
     private var botSheetListener: BotSheetListener? = null
@@ -92,6 +93,8 @@ class StatFragment : Fragment(), ViewPagerTouchListener {
                 registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
                     override fun onPageSelected(position: Int) {
                         super.onPageSelected(position)
+
+                        (adapter as StatViewPagerAdapter).animate(position)
 
                         when (position) {
                             0 -> { // 첫 번째 페이지 (StatDailyFragment)

--- a/app/src/main/java/com/example/yeongkkuel/presentation/stat/StatViewPagerAdapter.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/stat/StatViewPagerAdapter.kt
@@ -30,4 +30,10 @@ class StatViewPagerAdapter(
     }
 
     fun getTitle(position: Int): Int = fragments[position].title
+
+    fun animate(position: Int){
+        (fragments[position]?.fragment as? StatAnimationListener)?.animate()
+    }
+
+
 }

--- a/app/src/main/java/com/example/yeongkkuel/presentation/stat/daily/StatDailyFragment.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/stat/daily/StatDailyFragment.kt
@@ -14,6 +14,7 @@ import com.example.yeongkkuel.R
 import com.example.yeongkkuel.databinding.FragmentStatDailyBinding
 import com.example.yeongkkuel.presentation.botsheet.BotSheetUiState
 import com.example.yeongkkuel.presentation.botsheet.BotSheetViewModel
+import com.example.yeongkkuel.presentation.stat.StatAnimationListener
 import com.example.yeongkkuel.presentation.util.toMoneyString
 import com.github.mikephil.charting.animation.Easing
 import com.github.mikephil.charting.data.PieData
@@ -28,7 +29,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-class StatDailyFragment : Fragment() {
+class StatDailyFragment : Fragment(), StatAnimationListener {
     private var _binding: FragmentStatDailyBinding? = null
     private val binding: FragmentStatDailyBinding
         get() = requireNotNull(_binding) { "FragmentStatBinding -> null" }
@@ -181,5 +182,12 @@ class StatDailyFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    override fun animate() {
+        binding.pieChart.apply {
+            animateY(1400, Easing.EaseInOutQuad) // 애니메이션 적용
+            invalidate() // 차트를 새로 그리기
+        }
     }
 }

--- a/app/src/main/java/com/example/yeongkkuel/presentation/stat/monthly/StatMonthlyFragment.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/stat/monthly/StatMonthlyFragment.kt
@@ -66,14 +66,19 @@ class StatMonthlyFragment(
     }
 
     private fun onBind(uiState: StatMonthlyUiState)= with(binding){
-        calendarViewPagerAdapter.getCurrentFragment(vpCalendar)?.setTargetExpenditure(uiState.targetExpenditure)
+        when(uiState){
+            StatMonthlyUiState.Init -> {}
+            is StatMonthlyUiState.StatMonthly -> {
+                calendarViewPagerAdapter.getCurrentFragment(vpCalendar)?.setTargetExpenditure(uiState.targetExpenditure)
 
-        tvCurrentMonth.text = uiState.targetMonth.first.toString() + "년 " + uiState.targetMonth.second.toString() + "월"
+                tvCurrentMonth.text = uiState.targetMonth.first.toString() + "년 " + uiState.targetMonth.second.toString() + "월"
 
-        tvTotalSpending.text = uiState.totalSpending.toMoneyString() + "원"
+                tvTotalSpending.text = uiState.totalSpending.toMoneyString() + "원"
 
-        tvAchievementDay.text = (uiState.achieveDay?.toString() ?: "-") + "일"
-        tvRewardAmount.text = "+" + uiState.rewardsAmount.toString()
+                tvAchievementDay.text = (uiState.achieveDay?.toString() ?: "-") + "일"
+                tvRewardAmount.text = "+" + uiState.rewardsAmount.toString()
+            }
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/yeongkkuel/presentation/stat/monthly/StatMonthlyUiState.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/stat/monthly/StatMonthlyUiState.kt
@@ -3,35 +3,43 @@ package com.example.yeongkkuel.presentation.stat.monthly
 import com.example.yeongkkuel.presentation.util.Week
 import com.github.mikephil.charting.data.PieEntry
 
-data class StatMonthlyUiState(
-    val targetMonth: Pair<Int, Int>,// year, month
-    val totalSpending: Int,
-    val rewardsAmount: Int,
-    val achieveDay: Int?,
-    val calendarList: List<CalendarData>,
-    val targetExpenditure: Int?
-) {
-    sealed interface CalendarData {
-        data class CalendarDayOfWeek(
-            val dayOfWeek: Week
-        ) : CalendarData
+sealed class StatMonthlyUiState {
 
-        data class CalendarDay(
-            val targetMonth: Pair<Int, Int>,// year, month
-            val day: Int,
-            val pieDataList: List<PieEntry>
-        ) : CalendarData
-    }
+    // Initial state
+    data object Init : StatMonthlyUiState()
 
+    // State with data
+    data class StatMonthly(
+        val targetMonth: Pair<Int, Int>, // year, month
+        val totalSpending: Int,
+        val rewardsAmount: Int,
+        val achieveDay: Int?,
+        val calendarList: List<CalendarData>,
+        val targetExpenditure: Int?
+    ) : StatMonthlyUiState() {
 
-    companion object {
-        fun init() = StatMonthlyUiState(
-            targetMonth = Pair(2025, 1),
-            totalSpending = 0,
-            rewardsAmount = 140,
-            achieveDay = 13,
-            targetExpenditure = null,
-            calendarList = emptyList()
-        )
+        // Sealed interface for calendar data
+        sealed interface CalendarData {
+            data class CalendarDayOfWeek(
+                val dayOfWeek: Week
+            ) : CalendarData
+
+            data class CalendarDay(
+                val targetMonth: Pair<Int, Int>, // year, month
+                val day: Int,
+                val pieDataList: List<PieEntry>
+            ) : CalendarData
+        }
+
+        companion object {
+            fun init() = StatMonthly(
+                targetMonth = Pair(2025, 1),
+                totalSpending = 0,
+                rewardsAmount = 140,
+                achieveDay = 13,
+                targetExpenditure = null,
+                calendarList = emptyList()
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/yeongkkuel/presentation/stat/monthly/StatMonthlyViewModel.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/stat/monthly/StatMonthlyViewModel.kt
@@ -15,22 +15,22 @@ import java.util.Calendar
 import java.util.Date
 
 class StatMonthlyViewModel : ViewModel() {
-    private val _uiState = MutableStateFlow(StatMonthlyUiState.init())
+    private val _uiState = MutableStateFlow<StatMonthlyUiState>(StatMonthlyUiState.Init)
     val uiState = _uiState.asStateFlow()
 
     private val yeongkkuelService = RetrofitClient.statService
-    private val dayOfWeekList: List<StatMonthlyUiState.CalendarData> =
+    private val dayOfWeekList: List<StatMonthlyUiState.StatMonthly.CalendarData> =
         Week.getListItem().map { week ->
-            StatMonthlyUiState.CalendarData.CalendarDayOfWeek(week)
+            StatMonthlyUiState.StatMonthly.CalendarData.CalendarDayOfWeek(week)
         }
 
     fun getCalender(year: Int, month: Int) = viewModelScope.launch {
-        suspend fun List<StatMonthlyUiState.CalendarData.CalendarDay>.getData(): List<StatMonthlyUiState.CalendarData.CalendarDay> {
+        suspend fun List<StatMonthlyUiState.StatMonthly.CalendarData.CalendarDay>.getData(): List<StatMonthlyUiState.StatMonthly.CalendarData.CalendarDay> {
             try {
                 yeongkkuelService.getExpendituresMonthCalendar(year = year, month = month).run {
                     if (isSuccess) {
-                        _uiState.update { prev ->
-                            prev.copy(
+                        _uiState.update {
+                            StatMonthlyUiState.StatMonthly.init().copy(
                                 targetExpenditure = result.dayTargetExpenditure,
                                 achieveDay = result.achieveDays,
                                 rewardsAmount = result.rewards,
@@ -39,17 +39,18 @@ class StatMonthlyViewModel : ViewModel() {
                         }
 
                         val dataList = result.selectedMonthExpenses.map { expense ->
-                            val pieDataList = result.dayTargetExpenditure?.let { targetExpenditure ->
-                                val rest = targetExpenditure - expense.expenditure
-                                mutableListOf<PieEntry>().apply {
-                                    add(PieEntry(expense.expenditure.toFloat(), "지출"))
-                                    if (rest > 0) {
-                                        add(PieEntry(rest.toFloat(), "나머지"))
+                            val pieDataList =
+                                result.dayTargetExpenditure?.let { targetExpenditure ->
+                                    val rest = targetExpenditure - expense.expenditure
+                                    mutableListOf<PieEntry>().apply {
+                                        add(PieEntry(expense.expenditure.toFloat(), "지출"))
+                                        if (rest > 0) {
+                                            add(PieEntry(rest.toFloat(), "나머지"))
+                                        }
                                     }
-                                }
-                            } ?: emptyList()
+                                } ?: emptyList()
 
-                            StatMonthlyUiState.CalendarData.CalendarDay(
+                            StatMonthlyUiState.StatMonthly.CalendarData.CalendarDay(
                                 targetMonth = Pair(year, month),
                                 day = expense.expenseDate.getDay(),
                                 pieDataList = pieDataList
@@ -83,7 +84,7 @@ class StatMonthlyViewModel : ViewModel() {
         suspend fun getDayList(
             year: Int,
             month: Int
-        ): List<StatMonthlyUiState.CalendarData.CalendarDay> {
+        ): List<StatMonthlyUiState.StatMonthly.CalendarData.CalendarDay> {
             val calendar = Calendar.getInstance().apply {
                 set(Calendar.YEAR, year)
                 set(Calendar.MONTH, month - 1)
@@ -112,7 +113,7 @@ class StatMonthlyViewModel : ViewModel() {
 
                 val rest = if (targetSpending - daySpending > 0) targetSpending - daySpending else 0
 
-                StatMonthlyUiState.CalendarData.CalendarDay(
+                StatMonthlyUiState.StatMonthly.CalendarData.CalendarDay(
                     targetMonth = Pair(year, month),
                     day = day,
                     pieDataList = listOf(
@@ -127,7 +128,7 @@ class StatMonthlyViewModel : ViewModel() {
         val dayList = getDayList(year, month)
 
         _uiState.update { prev ->
-            prev.copy(
+            (prev as StatMonthlyUiState.StatMonthly).copy(
                 targetMonth = Pair(year, month),
                 calendarList = dayOfWeekList + dayList
             )

--- a/app/src/main/java/com/example/yeongkkuel/presentation/stat/monthly/adapter/StatMonthlyCalendarListAdapter.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/stat/monthly/adapter/StatMonthlyCalendarListAdapter.kt
@@ -21,7 +21,7 @@ import timber.log.Timber
 
 class StatMonthlyCalendarListAdapter(
     private val viewModel: BotSheetViewModel
-) : ListAdapter<StatMonthlyUiState.CalendarData, StatMonthlyCalendarListAdapter.ViewHolder>(
+) : ListAdapter<StatMonthlyUiState.StatMonthly.CalendarData, StatMonthlyCalendarListAdapter.ViewHolder>(
     StatMonthlyCalendarDiffUtil()
 ) {
     private var targetExpenditure: Int? = null
@@ -33,7 +33,7 @@ class StatMonthlyCalendarListAdapter(
     abstract inner class ViewHolder(
         view: View
     ) : RecyclerView.ViewHolder(view) {
-        abstract fun bind(item: StatMonthlyUiState.CalendarData)
+        abstract fun bind(item: StatMonthlyUiState.StatMonthly.CalendarData)
     }
 
     enum class ViewType {
@@ -43,8 +43,8 @@ class StatMonthlyCalendarListAdapter(
     inner class DayOfWeekViewHolder(
         private val binding: ItemCalendarDayofweekBinding
     ) : ViewHolder(binding.root) {
-        override fun bind(item: StatMonthlyUiState.CalendarData)= with(binding) {
-            (item as StatMonthlyUiState.CalendarData.CalendarDayOfWeek).let{
+        override fun bind(item: StatMonthlyUiState.StatMonthly.CalendarData)= with(binding) {
+            (item as StatMonthlyUiState.StatMonthly.CalendarData.CalendarDayOfWeek).let{
                 tvDayOfWeek.text = it.dayOfWeek.kor
             }
         }
@@ -54,8 +54,8 @@ class StatMonthlyCalendarListAdapter(
     inner class DayViewHolder(
         private val binding: ItemCalendarDayBinding
     ) : ViewHolder(binding.root) {
-        override fun bind(item: StatMonthlyUiState.CalendarData): Unit = with(binding) {
-            (item as StatMonthlyUiState.CalendarData.CalendarDay).let { dayItem ->
+        override fun bind(item: StatMonthlyUiState.StatMonthly.CalendarData): Unit = with(binding) {
+            (item as StatMonthlyUiState.StatMonthly.CalendarData.CalendarDay).let { dayItem ->
                 fun initData() {
                     tvDay.text = dayItem.day.toString()
                     if(targetExpenditure == null){
@@ -111,13 +111,13 @@ class StatMonthlyCalendarListAdapter(
     inner class UnknownViewHolder(
         private val binding: ItemUnknownBinding
     ) : ViewHolder(binding.root) {
-        override fun bind(item: StatMonthlyUiState.CalendarData) {
+        override fun bind(item: StatMonthlyUiState.StatMonthly.CalendarData) {
         }
     }
 
     override fun getItemViewType(position: Int): Int = when (getItem(position)) {
-        is StatMonthlyUiState.CalendarData.CalendarDayOfWeek -> ViewType.DayOfWeeK.ordinal
-        is StatMonthlyUiState.CalendarData.CalendarDay -> ViewType.Day.ordinal
+        is StatMonthlyUiState.StatMonthly.CalendarData.CalendarDayOfWeek -> ViewType.DayOfWeeK.ordinal
+        is StatMonthlyUiState.StatMonthly.CalendarData.CalendarDay -> ViewType.Day.ordinal
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder =
@@ -154,17 +154,17 @@ class StatMonthlyCalendarListAdapter(
 }
 
 private class StatMonthlyCalendarDiffUtil :
-    DiffUtil.ItemCallback<StatMonthlyUiState.CalendarData>() {
+    DiffUtil.ItemCallback<StatMonthlyUiState.StatMonthly.CalendarData>() {
     override fun areItemsTheSame(
-        oldItem: StatMonthlyUiState.CalendarData,
-        newItem: StatMonthlyUiState.CalendarData
+        oldItem: StatMonthlyUiState.StatMonthly.CalendarData,
+        newItem: StatMonthlyUiState.StatMonthly.CalendarData
     ): Boolean {
         return oldItem == newItem
     }
 
     override fun areContentsTheSame(
-        oldItem: StatMonthlyUiState.CalendarData,
-        newItem: StatMonthlyUiState.CalendarData
+        oldItem: StatMonthlyUiState.StatMonthly.CalendarData,
+        newItem: StatMonthlyUiState.StatMonthly.CalendarData
     ): Boolean {
         return oldItem == newItem
     }

--- a/app/src/main/java/com/example/yeongkkuel/presentation/stat/monthly/adapter/viewpager/StatMonthlyCalendarFrameFragment.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/stat/monthly/adapter/viewpager/StatMonthlyCalendarFrameFragment.kt
@@ -86,7 +86,7 @@ class StatMonthlyCalendarFrameFragment(
     }
 
     private fun onBind(uiState: StatMonthlyUiState) = with(binding) {
-        listAdapter.submitList(uiState.calendarList)
+        if(uiState is StatMonthlyUiState.StatMonthly) listAdapter.submitList(uiState.calendarList)
     }
 
     fun setTargetExpenditure(targetExpenditure: Int?){

--- a/app/src/main/java/com/example/yeongkkuel/presentation/stat/weekly/StatWeeklyFragment.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/stat/weekly/StatWeeklyFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.StyleSpan
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -350,18 +351,16 @@ class StatWeeklyFragment(
     }
 
     override fun animate() {
-        val viewHolder1 = binding.rvCompare.findViewHolderForAdapterPosition(0) as? StatWeeklyCompareListAdapter.ViewHolder
-        val viewHolder2 = binding.rvCompare.findViewHolderForAdapterPosition(1) as? StatWeeklyCompareListAdapter.ViewHolder
+        val compareCnt = compareListAdapter.itemCount
 
-        viewHolder1?.let {
-            val item1 = compareListAdapter.currentList[0]
-            it.animateProgress(item1)
+        for (i in 0 until compareCnt) {
+            val viewHolder = binding.rvCompare.findViewHolderForAdapterPosition(i) as? StatWeeklyCompareListAdapter.ViewHolder
+            viewHolder?.let {
+                val item = compareListAdapter.currentList[i]  // 해당 인덱스의 아이템 가져오기
+                it.animateProgress(item)  // 애니메이션 적용
+            }
         }
 
-        viewHolder2?.let {
-            val item2 = compareListAdapter.currentList[1]
-            it.animateProgress(item2)
-        }
 
         // PieChart 애니메이션 추가
         binding.pieChart.apply {

--- a/app/src/main/java/com/example/yeongkkuel/presentation/stat/weekly/StatWeeklyFragment.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/stat/weekly/StatWeeklyFragment.kt
@@ -17,13 +17,12 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.yeongkkuel.R
 import com.example.yeongkkuel.databinding.FragmentStatWeeklyBinding
+import com.example.yeongkkuel.presentation.stat.StatAnimationListener
 import com.example.yeongkkuel.presentation.stat.weekly.adapter.StatWeeklyCompareListAdapter
 import com.example.yeongkkuel.presentation.stat.weekly.adapter.StatWeeklyPieChartCategoryListAdapter
 import com.example.yeongkkuel.presentation.stat.weekly.adapter.StatWeeklyWeekListAdapter
-import com.example.yeongkkuel.presentation.util.Week
 import com.example.yeongkkuel.presentation.util.toMoneyString
 import com.github.mikephil.charting.animation.Easing
-import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.data.LineData
 import com.github.mikephil.charting.data.LineDataSet
 import com.github.mikephil.charting.data.PieData
@@ -37,11 +36,10 @@ import java.time.LocalDate
 import java.time.format.TextStyle
 import java.util.Calendar
 import java.util.Locale
-import kotlin.math.exp
 
 class StatWeeklyFragment(
     private val viewModel: StatWeeklyViewModel
-) : Fragment() {
+) : Fragment(), StatAnimationListener {
     private var _binding: FragmentStatWeeklyBinding? = null
     private val binding: FragmentStatWeeklyBinding
         get() = requireNotNull(_binding) { "FragmentStatWeeklyBinding -> null" }
@@ -350,4 +348,27 @@ class StatWeeklyFragment(
         super.onDestroyView()
         _binding = null
     }
+
+    override fun animate() {
+        val viewHolder1 = binding.rvCompare.findViewHolderForAdapterPosition(0) as? StatWeeklyCompareListAdapter.ViewHolder
+        val viewHolder2 = binding.rvCompare.findViewHolderForAdapterPosition(1) as? StatWeeklyCompareListAdapter.ViewHolder
+
+        viewHolder1?.let {
+            val item1 = compareListAdapter.currentList[0]
+            it.animateProgress(item1)
+        }
+
+        viewHolder2?.let {
+            val item2 = compareListAdapter.currentList[1]
+            it.animateProgress(item2)
+        }
+
+        // PieChart 애니메이션 추가
+        binding.pieChart.apply {
+            animateY(1400, Easing.EaseInOutQuad) // 애니메이션 적용
+            invalidate() // 차트를 새로 그리기
+        }
+    }
+
+
 }

--- a/app/src/main/java/com/example/yeongkkuel/presentation/stat/weekly/StatWeeklyViewModel.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/stat/weekly/StatWeeklyViewModel.kt
@@ -58,20 +58,29 @@ class StatWeeklyViewModel : ViewModel() {
                     result.run {
                         _uiState.update { prev ->
                             prev.copy(
-                                compareList = listOf(
-                                    StatWeeklyUiState.CompareData.OthersCompare(
-                                        target = "${Age.getEnToKor(age)} ${Job.getEnToKor(job)}",
-                                        targetSpending = averageExpenditure,
-                                        mySpending = myAverageExpenditure,
-                                        spendingUnit = SpendingUnit.WEEK,
-                                        percentile = topPercent
-                                    ),
-                                    StatWeeklyUiState.CompareData.PastCompare(
-                                        pastSpending = lastWeekExpenditure,
-                                        currentSpending = thisWeekExpenditure,
-                                        spendingUnit = SpendingUnit.WEEK
+                                compareList = mutableListOf<StatWeeklyUiState.CompareData>().apply {
+                                    // 조건에 맞는 경우에만 OthersCompare 추가
+                                    if (!age.isNullOrEmpty() && !job.isNullOrEmpty() && averageExpenditure != null && myAverageExpenditure != null && topPercent != null) {
+                                        add(
+                                            StatWeeklyUiState.CompareData.OthersCompare(
+                                                target = "${Age.getEnToKor(age!!)} ${Job.getEnToKor(job!!)}",
+                                                targetSpending = averageExpenditure ?: 0,
+                                                mySpending = myAverageExpenditure,
+                                                spendingUnit = SpendingUnit.WEEK,
+                                                percentile = topPercent ?: 0
+                                            )
+                                        )
+                                    }
+
+                                    // PastCompare는 항상 추가
+                                    add(
+                                        StatWeeklyUiState.CompareData.PastCompare(
+                                            pastSpending = lastWeekExpenditure ?: 0,
+                                            currentSpending = thisWeekExpenditure,
+                                            spendingUnit = SpendingUnit.WEEK
+                                        )
                                     )
-                                ),
+                                },
                                 pieChartList = categories.map {
                                     StatWeeklyUiState.PieChartData(
                                         category = SpendingCategory.fromName(it.categoryName),

--- a/app/src/main/java/com/example/yeongkkuel/presentation/stat/weekly/adapter/StatWeeklyCompareListAdapter.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/stat/weekly/adapter/StatWeeklyCompareListAdapter.kt
@@ -6,6 +6,7 @@ import android.text.SpannableString
 import android.text.Spanned
 import android.text.style.StyleSpan
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import android.view.animation.DecelerateInterpolator
 import android.widget.ProgressBar

--- a/app/src/main/java/com/example/yeongkkuel/presentation/stat/weekly/adapter/StatWeeklyCompareListAdapter.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/stat/weekly/adapter/StatWeeklyCompareListAdapter.kt
@@ -1,11 +1,14 @@
 package com.example.yeongkkuel.presentation.stat.weekly.adapter
 
+import android.animation.ValueAnimator
 import android.graphics.Typeface
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.style.StyleSpan
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.view.animation.DecelerateInterpolator
+import android.widget.ProgressBar
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -104,6 +107,41 @@ class StatWeeklyCompareListAdapter(
                 }
             }
         }
+
+        fun animateProgress(item: StatWeeklyUiState.CompareData) = with(binding){
+            fun animateProgress(progressBar: ProgressBar, targetValue: Int){
+                val animator = ValueAnimator.ofInt(0, targetValue)
+                animator.duration = 2000 // 1초 동안 애니메이션
+                animator.interpolator = DecelerateInterpolator() // 부드러운 감속 효과
+                animator.addUpdateListener {
+                    progressBar.progress = it.animatedValue as Int
+                }
+                animator.start()
+            }
+
+            when(item){
+                is StatWeeklyUiState.CompareData.OthersCompare ->{
+                    val maxValue = maxOf(item.mySpending, item.targetSpending).takeIf { it > 0 } ?: 1
+                    progressComparedTarget.max = 100
+                    progressMyTarget.max = 100
+
+                    animateProgress(progressComparedTarget, (item.targetSpending * 100 / maxValue))
+                    animateProgress(progressMyTarget, (item.mySpending * 100 / maxValue))
+                }
+                is StatWeeklyUiState.CompareData.PastCompare -> {
+                    val maxValue = maxOf(item.currentSpending, item.pastSpending).takeIf { it > 0 } ?: 1
+                    progressComparedTarget.max = 100
+                    progressMyTarget.max = 100
+
+                    animateProgress(progressComparedTarget, (item.pastSpending * 100 / maxValue))
+                    animateProgress(progressMyTarget, (item.currentSpending * 100 / maxValue))
+                }
+            }
+        }
+    }
+
+    fun animateProgressOnViewHolder(holder: ViewHolder, item: StatWeeklyUiState.CompareData) {
+        holder.animateProgress(item)
     }
 
 

--- a/app/src/main/res/drawable/bg_box_lightpurple.xml
+++ b/app/src/main/res/drawable/bg_box_lightpurple.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <corners android:radius="6dp" />
-    <solid android:color="@color/main4"/>
-</shape>

--- a/app/src/main/res/drawable/bg_progress_lightpurple.xml
+++ b/app/src/main/res/drawable/bg_progress_lightpurple.xml
@@ -4,9 +4,7 @@
         <scale android:scaleWidth="100%">
             <shape>
                 <corners android:radius="6dp" />
-                <stroke
-                    android:width="1dp"
-                    android:color="@color/main4" />
+                <solid android:color="@color/main4" />
             </shape>
         </scale>
     </item>

--- a/app/src/main/res/layout/fragment_stat_weekly.xml
+++ b/app/src/main/res/layout/fragment_stat_weekly.xml
@@ -51,7 +51,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/space_x_small"
-            android:paddingHorizontal="32dp"
             android:paddingVertical="@dimen/space_x_small"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/cl_topCl">
@@ -63,6 +62,7 @@
                 android:orientation="vertical"
                 app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
                 app:layout_constraintTop_toTopOf="parent"
+                android:paddingHorizontal="@dimen/space_median"
                 app:spanCount="7"
                 tools:itemCount="7"
                 tools:listitem="@layout/item_stat_weekly_week" />
@@ -73,6 +73,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="120dp"
                 android:layout_marginTop="@dimen/space_x_small"
+                android:paddingHorizontal="@dimen/space_x_large"
                 app:layout_constraintTop_toBottomOf="@id/rv_weekSending" />
 
             <View
@@ -82,6 +83,7 @@
                 android:background="@color/sub1"
                 app:layout_constraintBottom_toBottomOf="@id/lineChart"
                 app:layout_constraintEnd_toEndOf="@id/lineChart"
+                android:layout_marginHorizontal="@dimen/space_median"
                 app:layout_constraintStart_toStartOf="@id/lineChart"
                 app:layout_constraintTop_toTopOf="@id/lineChart" />
 

--- a/app/src/main/res/layout/item_stat_weekly_compare.xml
+++ b/app/src/main/res/layout/item_stat_weekly_compare.xml
@@ -15,20 +15,29 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:text="20대 직장인 중 상위 10%" />
 
+    <ProgressBar
+        android:id="@+id/progress_comparedTarget"
+        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+        android:layout_width="0dp"
+        android:layout_height="40dp"
+        android:layout_marginTop="@dimen/sp_small"
+        android:progressDrawable="@drawable/bg_box_strok_lightpurple"
+        app:layout_constraintStart_toStartOf="@id/tv_compareDescription"
+        app:layout_constraintTop_toBottomOf="@id/tv_compareDescription"
+        android:progress="0"
+        tools:progress="100"
+        app:layout_constraintWidth_percent="0.5" />
+
     <TextView
         android:id="@+id/tv_comparedTarget"
         style="@style/small_regul"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/sp_small"
-        android:background="@drawable/bg_box_strok_lightpurple"
-        android:paddingVertical="@dimen/space_x_small"
-        android:paddingStart="@dimen/sp_small"
-        android:paddingEnd="114dp"
+        android:layout_marginStart="@dimen/sp_small"
+        app:layout_constraintBottom_toBottomOf="@id/progress_comparedTarget"
         app:layout_constraintStart_toStartOf="@id/tv_compareDescription"
-        app:layout_constraintTop_toBottomOf="@id/tv_compareDescription"
+        app:layout_constraintTop_toTopOf="@id/progress_comparedTarget"
         tools:text="20대 직장인 평균" />
-
 
     <TextView
         android:id="@+id/tv_comparedMoney"
@@ -37,7 +46,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/space_x_small"
         app:layout_constraintBottom_toBottomOf="@id/tv_comparedTarget"
-        app:layout_constraintStart_toEndOf="@id/tv_comparedTarget"
+        app:layout_constraintStart_toEndOf="@id/progress_comparedTarget"
         app:layout_constraintTop_toTopOf="@id/tv_comparedTarget"
         tools:text="15,700원" />
 
@@ -51,19 +60,29 @@
         app:layout_constraintStart_toEndOf="@id/tv_comparedMoney"
         tools:text=" /일" />
 
+    <ProgressBar
+        android:id="@+id/progress_myTarget"
+        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+        android:layout_width="0dp"
+        android:layout_height="40dp"
+        android:layout_marginTop="@dimen/sp_small"
+        android:progressDrawable="@drawable/bg_progress_lightpurple"
+        android:progress="0"
+        tools:progress="100"
+        app:layout_constraintStart_toStartOf="@id/progress_comparedTarget"
+        app:layout_constraintTop_toBottomOf="@id/progress_comparedTarget"
+        app:layout_constraintWidth_percent="0.5" />
+
     <TextView
         android:id="@+id/tv_myTarget"
         style="@style/small_regul"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/space_x_small"
-        android:background="@drawable/bg_box_lightpurple"
-        android:paddingVertical="@dimen/space_x_small"
-        android:paddingStart="@dimen/space_small"
-        android:paddingEnd="28dp"
+        android:layout_marginStart="@dimen/space_small"
         android:text="나"
-        app:layout_constraintStart_toStartOf="@id/tv_comparedTarget"
-        app:layout_constraintTop_toBottomOf="@id/tv_comparedTarget" />
+        app:layout_constraintBottom_toBottomOf="@id/progress_myTarget"
+        app:layout_constraintStart_toStartOf="@id/progress_myTarget"
+        app:layout_constraintTop_toTopOf="@id/progress_myTarget" />
 
 
     <TextView
@@ -74,7 +93,7 @@
         android:layout_marginStart="@dimen/space_x_small"
         android:textColor="@color/main1"
         app:layout_constraintBottom_toBottomOf="@id/tv_myTarget"
-        app:layout_constraintStart_toEndOf="@id/tv_myTarget"
+        app:layout_constraintStart_toEndOf="@id/progress_myTarget"
         app:layout_constraintTop_toTopOf="@id/tv_myTarget"
         tools:text="15,700원" />
 
@@ -94,6 +113,8 @@
         android:layout_height="@dimen/space_median"
         android:layout_marginTop="@dimen/space_large"
         android:background="@color/black0"
-        app:layout_constraintTop_toBottomOf="@id/tv_myTarget" />
+        app:layout_constraintTop_toBottomOf="@id/progress_myTarget" />
+
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_stat_weekly_week.xml
+++ b/app/src/main/res/layout/item_stat_weekly_week.xml
@@ -2,7 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
     <ImageView


### PR DESCRIPTION
## *📌 Issue*
- closed #issue number
<!-- closed를 붙이면 해당 이슈가 PR과 함께 자동으로 close -->

## *⛳️ Work Description*
- 지출 viewpager 이동 시 navigation
- 지출 주간 layout변경, 
- 지출 주간 직업, 나이 설정 안되있을 시 안보이도록 표시
- 지출 api 경로 변경 수정
- 지출 월간 클릭 이벤트 작동하도록 변경

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

## *📢 To Reviewers*
mainActivity에 
       // 스플래시 화면 종료 조건: 데이터가 로드되지 않았다면 계속 유지
//        splashScreen.setKeepOnScreenCondition {
//            !isDataLoaded()  // 데이터가 아직 로드되지 않았다면 true를 반환해서 스플래시 유지
//        }
주석 처리 해놨습니다. 잘 실행이 안될 때가 있었거든요.. 확인 부탁드려요.

//민주, 지현

같은 역할의 data class field가 중복되어 있음(categoryList, 전에 pr 내 코멘트를 봤을 때 둘 중 하나를 지우고그에 따른 수정을 하겠다고 알았는데 그대로 쓴다고 적은 것을 내가 잘못 이해함.)

이름, 타입이 헷갈리도록 설정(spendingHistoryList의 경우 지출 수정 로직을 위한 변수인 것 같은데 그럴 경우 list일 필요가 없으며 변수명 또한  selectedSpending같은 이름으로 변경해야 함)

패키지 관리(api Service interface가 service 패키지 내부에 존재하지 않음)

관심사 분리(지출 삭제 로직, 지출 수정 로직은 각각의 viewModel을 만들어서 하는 것이 좋은 거 같음. 많은 양의 코드가 아니라 생각할 지라도 제대로 주석으로 나누고 정리해도 코드가 길어지면 알아보기 힘들어지는데 정리가 잘 되어있으면 괜찮다고 생각하지만 정리도 제대로 안되어 있음. 확인을 위한 statFlow, liveData도 뭐에 쓰는 로직인 지 제대로 파악이 안될 수 있음)


-- > 지출 생성 후 지출 기록 조회에 등록되기까지 약간의 텀이 존재

//유찬

repository 사용 여부( 저번에 repository를 사용하는 이유에 대해 물어보고 팀 내에서 코드 스타일이 통일되지 않으면 유지보수가 어려워지니 적용하려면 팀원들에게 한번 이야기해보자 말함. 하지만 이야기를 나누지 않은 것 같음)
 

개발에 바쁘신 거 같아서 고치진 못할 거 같고 다음부터 참고하라고 코드 보면서 생각 나는 것들 적었습니다.

<!-- PR 제목 형식: [FEATURE/#이슈번호] 작업 주제 -->
