### PR TITLE
fix/#89: 지출 내역, 수정 페이지에 사진 보이게 함

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         manifestPlaceholders["NATIVE_APP_KEY"] = nativeAppKey
 
         applicationId = "com.example.yeongkkuel"
-        minSdk = 30
+        minSdk = 29
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/app/src/main/java/com/example/yeongkkuel/network/response/expenditure/MonthExpendituresCategory.kt
+++ b/app/src/main/java/com/example/yeongkkuel/network/response/expenditure/MonthExpendituresCategory.kt
@@ -19,6 +19,6 @@ data class MonthExpendituresCategory(
         @SerializedName("expenseId") val expenseId: Int,       // 지출 ID
         @SerializedName("expenseName") val expenseName: String, // 지출 이름
         @SerializedName("expenseAmount") val expenseAmount: Int, // 금액
-        @SerializedName("imgExist") val imgExist: Boolean
+        @SerializedName("imgExist") val imgExist: String
     )
 }

--- a/app/src/main/java/com/example/yeongkkuel/presentation/base/MainActivity.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/base/MainActivity.kt
@@ -438,7 +438,7 @@ class MainActivity : AppCompatActivity(), BotSheetListener {
         expensePrice: Int,
         categoryColor: Int,
         categoryName: String,
-        imageUrl: Boolean
+        imageUrl: String
     ) {
         Log.d(
             "MainActivity",
@@ -455,6 +455,7 @@ class MainActivity : AppCompatActivity(), BotSheetListener {
             putInt("expensePrice", expensePrice)
             putInt("categoryColor", categoryColor)
             putString("categoryName", categoryName)
+            putString("imageUrl", imageUrl)
         }
 
         navController.navigate(R.id.navigation_expense_view, bundle)

--- a/app/src/main/java/com/example/yeongkkuel/presentation/botsheet/BotSheetHistoryListAdapter.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/botsheet/BotSheetHistoryListAdapter.kt
@@ -43,7 +43,7 @@ class BotSheetHistoryListAdapter(
                  root.visibility = View.VISIBLE
              }
 
-            if (item.imgExist) {
+            if (!item.imgExist.isNullOrEmpty()) { // ✅ imageUrl 값이 있을 때만 아이콘 보이기
                 icPhotoIncluded.visibility = View.VISIBLE
             } else {
                 icPhotoIncluded.visibility = View.GONE

--- a/app/src/main/java/com/example/yeongkkuel/presentation/botsheet/BotSheetListener.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/botsheet/BotSheetListener.kt
@@ -5,7 +5,7 @@ interface BotSheetListener {
     fun setBotSheetGone()
     fun setBotSheetVisible()
     fun navigateToExpenseEntry(selectedCategory: String, categoryColor: Int)
-    fun navigateToExpenseView(expenseId: Int, expenseName: String, expensePrice: Int, categoryColor: Int, categoryName: String, imageUrl: Boolean)
+    fun navigateToExpenseView(expenseId: Int, expenseName: String, expensePrice: Int, categoryColor: Int, categoryName: String, imageUrl: String)
     fun navigateToCategoryAddFragment()
     fun onNoExpenseChanged(isNoExpense: Boolean) // 무지출 여부 전달
 }

--- a/app/src/main/java/com/example/yeongkkuel/presentation/botsheet/BotSheetUiState.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/botsheet/BotSheetUiState.kt
@@ -21,7 +21,7 @@ data class BotSheetUiState(
             val id: Int,
             val name: String,       // 지출 이름
             val price: Int,         // 금액
-            val imgExist: Boolean   // 사진 URL 추가
+            val imgExist: String   // 사진 URL 추가
         )
     }
 

--- a/app/src/main/java/com/example/yeongkkuel/presentation/botsheet/BotSheetViewModel.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/botsheet/BotSheetViewModel.kt
@@ -371,7 +371,7 @@ class BotSheetViewModel : ViewModel() {
                                             id = expense.expenseId,
                                             name = expense.expenseName,
                                             price = expense.expenseAmount,
-                                            imgExist = expense.imgExist
+                                            imgExist = expense.imgExist ?: ""
                                         )
                                     }
                                 )

--- a/app/src/main/java/com/example/yeongkkuel/presentation/home/entry/ExpenseEditFragment.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/home/entry/ExpenseEditFragment.kt
@@ -18,6 +18,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.example.yeongkkuel.R
 import com.example.yeongkkuel.databinding.FragmentExpenseEditBinding
 import com.example.yeongkkuel.presentation.botsheet.BotSheetViewModel
@@ -125,18 +126,23 @@ class ExpenseEditFragment : Fragment() {
     }
 
 
-    // 이미지 불러오기
+    // 기존 이미지를 불러오는 함수 수정
     private fun loadExistingImage(imageUrl: String?) {
         if (!imageUrl.isNullOrEmpty()) {
             Glide.with(this)
                 .load(imageUrl)
+                .override(1000, 1000) // ✅ 크기 조정 (너비 1000px, 높이 600px)
+                .centerCrop() // ✅ 꽉 차게 표시
+                .transform(RoundedCorners(50)) // ✅ 모서리를 둥글게
                 .into(binding.imgPhotoFrame)
-            binding.ivPhotoIcon.visibility = View.GONE
+
+            binding.ivPhotoIcon.visibility = View.GONE // ✅ 아이콘 숨김
         } else {
             binding.imgPhotoFrame.setImageResource(R.drawable.bg_photo_input) // 기본 이미지 설정
             binding.ivPhotoIcon.visibility = View.VISIBLE
         }
     }
+
 
     // 갤러리 열기
     private fun openGallery() {
@@ -151,17 +157,21 @@ class ExpenseEditFragment : Fragment() {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == PICK_IMAGE_REQUEST && resultCode == AppCompatActivity.RESULT_OK) {
             data?.data?.let { uri ->
-                selectedImageUri = uri // 선택한 이미지 저장
+                selectedImageUri = uri // ✅ 선택한 이미지 저장
 
                 // 🔹 Glide를 사용하여 이미지 미리보기 업데이트
                 Glide.with(this)
                     .load(uri)
+                    .override(500, 500) // ✅ 크기 조정
+                    .centerCrop() // ✅ 중앙 정렬
+                    .transform(RoundedCorners(50)) // ✅ 모서리 둥글게
                     .into(binding.imgPhotoFrame)
 
-                binding.ivPhotoIcon.visibility = View.GONE
+                binding.ivPhotoIcon.visibility = View.GONE // ✅ 아이콘 숨김
             }
         }
     }
+
 
     private fun enableEditing() {
         binding.etDetailInput.isEnabled = true
@@ -188,6 +198,9 @@ class ExpenseEditFragment : Fragment() {
         val etDetailInput = binding.etDetailInput
         val tvCharacterCount = binding.tvCharacterCount
 
+        val initialTextLength = etDetailInput.text?.length ?: 0
+        tvCharacterCount.text = "$initialTextLength/24"
+
         etDetailInput.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
 
@@ -205,13 +218,22 @@ class ExpenseEditFragment : Fragment() {
 
     // 쉼표 처리
     private fun setupAmountInput() {
-        binding.etAmountInput.addTextChangedListener(object : TextWatcher {
+        val etAmountInput = binding.etAmountInput
+
+        // 초기 값이 있을 경우 쉼표 추가
+        val initialText = etAmountInput.text.toString().trim().replace(",", "")
+        if (initialText.isNotEmpty()) {
+            val formatted = NumberFormat.getInstance(Locale.KOREAN).format(initialText.toLongOrNull() ?: 0)
+            etAmountInput.setText(formatted)
+        }
+
+        etAmountInput.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
 
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
 
             override fun afterTextChanged(s: Editable?) {
-                binding.etAmountInput.removeTextChangedListener(this)
+                etAmountInput.removeTextChangedListener(this)
 
                 val rawInput = s?.toString()?.replace(",", "") ?: ""
                 val input = rawInput.toLongOrNull() ?: 0
@@ -224,14 +246,15 @@ class ExpenseEditFragment : Fragment() {
                 val formatted = NumberFormat.getInstance(Locale.KOREAN).format(limitedValue)
 
                 if (formatted != s.toString()) {
-                    binding.etAmountInput.setText(formatted)
-                    binding.etAmountInput.setSelection(formatted.length)
+                    etAmountInput.setText(formatted)
+                    etAmountInput.setSelection(formatted.length)
                 }
 
-                binding.etAmountInput.addTextChangedListener(this)
+                etAmountInput.addTextChangedListener(this)
             }
         })
     }
+
 
     // 수정 API 호출
     private fun saveExpense() {

--- a/app/src/main/java/com/example/yeongkkuel/presentation/home/entry/ExpenseEntryFragment.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/home/entry/ExpenseEntryFragment.kt
@@ -300,7 +300,7 @@ class ExpenseEntryFragment : Fragment() {
             expenseViewModel.createExpense(expenseRequest, imagePart) { response ->
                 if (response?.isSuccess == true) {
                     Toast.makeText(requireContext(), "지출 내역이 저장되었습니다.", Toast.LENGTH_SHORT).show()
-                    handleNavigationAfterSave(view)
+                    //handleNavigationAfterSave(view)
                 } else {
                     Toast.makeText(requireContext(), "지출 내역 저장 실패.", Toast.LENGTH_SHORT).show()
                 }

--- a/app/src/main/java/com/example/yeongkkuel/presentation/home/entry/ExpenseEntryFragment.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/home/entry/ExpenseEntryFragment.kt
@@ -359,7 +359,7 @@ class ExpenseEntryFragment : Fragment() {
             id = 1,
             name = detail,
             price = if (isNoExpenseChecked) 0 else amount,
-            imgExist = false
+            imgExist = selectedImageUri?.toString() ?: ""
         )
 
         botSheetViewModel.addExpenseHistory(expenseHistory)
@@ -454,9 +454,9 @@ class ExpenseEntryFragment : Fragment() {
             data?.data?.let { uri ->
                 selectedImageUri = uri // ✅ 선택한 이미지 URI 저장
 
-                // 🔹 Glide를 사용하여 미리보기 적용 가능
                 val imgPhotoFrame = view?.findViewById<ImageView>(R.id.img_photo_frame)
                 val ivPhotoIcon = view?.findViewById<ImageView>(R.id.iv_photo_icon)
+
                 Glide.with(this)
                     .load(uri)
                     .override(500, 500) // ✅ 크기 조정 (236x236)
@@ -468,7 +468,6 @@ class ExpenseEntryFragment : Fragment() {
             }
         }
     }
-
 //
 //    override fun onDestroyView() {
 //        super.onDestroyView()

--- a/app/src/main/java/com/example/yeongkkuel/presentation/home/entry/ExpenseViewFragment.kt
+++ b/app/src/main/java/com/example/yeongkkuel/presentation/home/entry/ExpenseViewFragment.kt
@@ -18,6 +18,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.example.yeongkkuel.R
 import com.example.yeongkkuel.databinding.FragmentExpenseViewBinding
 import com.example.yeongkkuel.presentation.botsheet.BotSheetUiState
@@ -98,12 +99,17 @@ class ExpenseViewFragment : Fragment() {
         if (imageUrl.isNotEmpty()) {
             Glide.with(binding.imgPhotoFrame.context)
                 .load(imageUrl)
+                .override(1000, 1000) // ✅ 크기 조정 (너비 1000px, 높이 600px)
+                .centerCrop() // ✅ 꽉 차게 표시
+                .transform(RoundedCorners(50)) // ✅ 모서리를 둥글게
                 .into(binding.imgPhotoFrame)
-            binding.ivPhotoIcon.visibility = View.GONE
+
+            binding.ivPhotoIcon.visibility = View.GONE // ✅ 아이콘 숨김
         } else {
             binding.imgPhotoFrame.setImageResource(R.drawable.bg_photo_input)
             binding.ivPhotoIcon.visibility = View.VISIBLE
         }
+
 
         // "trash" 카테고리인지 확인 후 숨김 처리
         if (categoryName.lowercase() == "trash") {

--- a/app/src/main/res/layout/fragment_expense_entry.xml
+++ b/app/src/main/res/layout/fragment_expense_entry.xml
@@ -310,6 +310,7 @@
                     android:layout_height="wrap_content"
                     android:src="@drawable/bg_photo_input"/>
 
+
                 <ImageView
                     android:id="@+id/iv_photo_icon"
                     android:layout_width="24dp"

--- a/app/src/main/res/layout/fragment_expense_view.xml
+++ b/app/src/main/res/layout/fragment_expense_view.xml
@@ -114,25 +114,27 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_content"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@id/cl_toolbar"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_height="match_parent"
             android:layout_marginStart="16dp"
             android:layout_marginEnd="16dp"
-            android:layout_marginBottom="16dp"
-            android:padding="10dp">
+            android:padding="10dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/cl_toolbar"
+            app:layout_constraintVertical_bias="1.0">
 
             <!-- 날짜 -->
             <TextView
                 android:id="@+id/tv_expense_date"
+                style="@style/expense_sectionTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="날짜"
-                style="@style/expense_sectionTitle"
+                app:layout_constraintBaseline_toBaselineOf="@id/tv_date_input"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBaseline_toBaselineOf="@id/tv_date_input" />
+                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/tv_date_input"
@@ -140,60 +142,60 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="50dp"
                 android:background="@drawable/bg_edit_text"
-                android:textColor="@color/main1"
-                android:textSize="15sp"
-                android:paddingHorizontal="5dp"
-                android:paddingVertical="5dp"
                 android:clickable="true"
+                android:enabled="true"
                 android:focusable="true"
                 android:gravity="center"
-                android:enabled="true"
+                android:paddingHorizontal="5dp"
+                android:paddingVertical="5dp"
+                android:textColor="@color/main1"
+                android:textSize="15sp"
                 app:layout_constraintStart_toEndOf="@id/tv_expense_date"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <!-- 카테고리 -->
             <TextView
                 android:id="@+id/tv_expense_category"
+                style="@style/expense_sectionTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="카테고리"
-                style="@style/expense_sectionTitle"
                 android:layout_marginTop="35dp"
+                android:text="카테고리"
+                android:visibility="gone"
+                app:layout_constraintBaseline_toBaselineOf="@id/tv_category_input"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/tv_expense_date"
-                app:layout_constraintBaseline_toBaselineOf="@id/tv_category_input"
-                android:visibility="gone"
-                tools:visibility="visible"/>
+                tools:visibility="visible" />
 
             <TextView
                 android:id="@+id/tv_category_input"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="17dp"
+                android:layout_marginTop="35dp"
                 android:background="@drawable/bg_edit_text"
                 android:clickable="true"
-                android:focusable="true"
-                android:inputType="text"
                 android:enabled="true"
-                android:textColor="@color/black"
-                android:textSize="15sp"
+                android:focusable="true"
+                android:gravity="center"
+                android:inputType="text"
                 android:paddingHorizontal="5dp"
                 android:paddingVertical="5dp"
-                android:layout_marginTop="35dp"
-                android:layout_marginStart="17dp"
-                android:gravity="center"
+                android:textColor="@color/black"
+                android:textSize="15sp"
+                android:visibility="gone"
                 app:layout_constraintStart_toEndOf="@id/tv_expense_category"
                 app:layout_constraintTop_toBottomOf="@id/tv_date_input"
-                android:visibility="gone"
-                tools:visibility="visible"/>
+                tools:visibility="visible" />
 
             <!-- 지출 내용 -->
             <TextView
                 android:id="@+id/tv_expense_detail"
+                style="@style/expense_sectionTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="지출 내용"
-                style="@style/expense_sectionTitle"
                 android:layout_marginTop="35dp"
+                android:text="지출 내용"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/tv_expense_category" />
 
@@ -201,12 +203,12 @@
                 android:id="@+id/cl_detail_input"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="@drawable/bg_edit_text"
                 android:layout_marginStart="13dp"
                 android:layout_marginTop="35dp"
+                android:background="@drawable/bg_edit_text"
+                app:layout_constraintBottom_toBottomOf="@id/tv_expense_detail"
                 app:layout_constraintStart_toEndOf="@id/tv_expense_detail"
-                app:layout_constraintTop_toBottomOf="@id/tv_category_input"
-                app:layout_constraintBottom_toBottomOf="@id/tv_expense_detail">
+                app:layout_constraintTop_toBottomOf="@id/tv_category_input">
 
                 <TextView
                     android:id="@+id/et_detail_input"
@@ -214,12 +216,12 @@
                     android:layout_height="wrap_content"
                     android:background="@drawable/bg_edit_text"
                     android:clickable="true"
+                    android:enabled="true"
                     android:focusable="true"
                     android:gravity="start|center_vertical"
                     android:paddingHorizontal="10dp"
                     android:paddingVertical="5dp"
                     android:textColor="@color/main1"
-                    android:enabled="true"
                     android:textSize="15sp"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
@@ -234,6 +236,8 @@
                 android:id="@+id/tv_detail_input_view"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="13dp"
+                android:layout_marginTop="35dp"
                 android:layout_marginEnd="10dp"
                 android:background="@drawable/bg_edit_text"
                 android:clickable="true"
@@ -241,45 +245,43 @@
                 android:gravity="start|center_vertical"
                 android:paddingHorizontal="10dp"
                 android:paddingVertical="5dp"
-                android:layout_marginStart="13dp"
-                android:layout_marginTop="35dp"
                 android:textColor="@color/black"
                 android:textSize="15sp"
                 android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@id/tv_expense_detail"
                 app:layout_constraintStart_toEndOf="@id/tv_expense_detail"
-                app:layout_constraintTop_toBottomOf="@id/tv_category_input"
-                app:layout_constraintBottom_toBottomOf="@id/tv_expense_detail"/>
+                app:layout_constraintTop_toBottomOf="@id/tv_category_input" />
 
 
             <!--  지출액 -->
             <TextView
                 android:id="@+id/tv_expense_amount"
+                style="@style/expense_sectionTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="지출액"
-                style="@style/expense_sectionTitle"
                 android:layout_marginTop="35dp"
+                android:text="지출액"
+                app:layout_constraintBaseline_toBaselineOf="@id/et_amount_input"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_expense_detail"
-                app:layout_constraintBaseline_toBaselineOf="@id/et_amount_input"/>
+                app:layout_constraintTop_toBottomOf="@+id/tv_expense_detail" />
 
             <TextView
                 android:id="@+id/et_amount_input"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="@drawable/bg_edit_text"
-                android:textColor="@color/main1"
-                android:textSize="15sp"
                 android:layout_marginStart="34dp"
                 android:layout_marginTop="35dp"
-                android:paddingHorizontal="10dp"
-                android:paddingVertical="5dp"
+                android:background="@drawable/bg_edit_text"
                 android:clickable="true"
+                android:enabled="true"
                 android:focusable="true"
                 android:inputType="number"
-                android:enabled="true"
+                android:paddingHorizontal="10dp"
+                android:paddingVertical="5dp"
+                android:textColor="@color/main1"
+                android:textSize="15sp"
                 app:layout_constraintStart_toEndOf="@id/tv_expense_amount"
-                app:layout_constraintTop_toBottomOf="@id/cl_detail_input"/>
+                app:layout_constraintTop_toBottomOf="@id/cl_detail_input" />
 
             <TextView
                 android:id="@+id/tv_currency"
@@ -289,24 +291,24 @@
                 android:text="원"
                 android:textColor="@color/black"
                 android:textSize="15sp"
-                app:layout_constraintStart_toEndOf="@id/et_amount_input"
-                app:layout_constraintBaseline_toBaselineOf="@id/et_amount_input" />
+                app:layout_constraintBaseline_toBaselineOf="@id/et_amount_input"
+                app:layout_constraintStart_toEndOf="@id/et_amount_input" />
 
             <!-- 지출 내역 - 지출액 보기-->
             <TextView
                 android:id="@+id/tv_amount_input_view"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:background="@drawable/bg_edit_text"
-                android:textColor="@color/black"
-                android:textSize="15sp"
                 android:layout_marginStart="34dp"
                 android:layout_marginTop="35dp"
+                android:background="@drawable/bg_edit_text"
                 android:paddingHorizontal="10dp"
                 android:paddingVertical="5dp"
+                android:textColor="@color/black"
+                android:textSize="15sp"
                 android:visibility="gone"
                 app:layout_constraintStart_toEndOf="@id/tv_expense_amount"
-                app:layout_constraintTop_toBottomOf="@id/cl_detail_input"/>
+                app:layout_constraintTop_toBottomOf="@id/cl_detail_input" />
 
             <TextView
                 android:id="@+id/tv_currency_view"
@@ -317,9 +319,8 @@
                 android:textColor="@color/black"
                 android:textSize="15sp"
                 android:visibility="gone"
-                app:layout_constraintStart_toEndOf="@id/tv_amount_input_view"
-                app:layout_constraintBaseline_toBaselineOf="@id/et_amount_input" />
-
+                app:layout_constraintBaseline_toBaselineOf="@id/et_amount_input"
+                app:layout_constraintStart_toEndOf="@id/tv_amount_input_view" />
 
 
             <!-- 무지출 체크 -->
@@ -328,51 +329,51 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"
+                android:visibility="gone"
                 app:layout_constraintStart_toStartOf="@id/et_amount_input"
-                app:layout_constraintTop_toBottomOf="@id/et_amount_input"
-                android:visibility="gone">
+                app:layout_constraintTop_toBottomOf="@id/et_amount_input">
 
                 <ImageView
                     android:id="@+id/iv_circle_expense_unchecked"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:src="@drawable/ic_radio_unchecked"
                     android:layout_marginTop="5dp"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"/>
+                    android:src="@drawable/ic_radio_unchecked"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
                 <ImageView
                     android:id="@+id/iv_circle_expense_checked"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="5dp"
                     android:src="@drawable/ic_radio_checked"
                     android:visibility="invisible"
-                    android:layout_marginTop="5dp"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"/>
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
                 <TextView
                     android:id="@+id/tv_no_expense_label"
+                    style="@style/body_regula"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="무지출로 기입하기"
-                    style="@style/body_regula"
-                    android:textSize="15sp"
-                    android:textColor="@color/black"
                     android:layout_marginStart="8dp"
+                    android:text="무지출로 기입하기"
+                    android:textColor="@color/black"
+                    android:textSize="15sp"
                     app:layout_constraintStart_toEndOf="@id/iv_circle_expense_unchecked"
-                    app:layout_constraintTop_toTopOf="parent"/>
+                    app:layout_constraintTop_toTopOf="parent" />
 
                 <TextView
                     android:id="@+id/tv_no_expense_hint"
+                    style="@style/small_regul"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:maxLines="2"
                     android:text="지출액이 없다면 무지출로 기입해주세요."
                     android:textColor="@color/black2"
-                    style="@style/small_regul"
                     android:textSize="12sp"
-                    android:maxLines="2"
-                    android:layout_marginTop="4dp"
                     app:layout_constraintStart_toStartOf="@id/tv_no_expense_label"
                     app:layout_constraintTop_toBottomOf="@id/tv_no_expense_label" />
 
@@ -381,29 +382,29 @@
             <!-- 사진 -->
             <TextView
                 android:id="@+id/tv_expense_photo"
+                style="@style/expense_sectionTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="45dp"
                 android:text="사진"
-                style="@style/expense_sectionTitle"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/cl_check_no_expense"/>
+                app:layout_constraintTop_toBottomOf="@id/cl_check_no_expense" />
 
             <FrameLayout
                 android:id="@+id/fl_photo_frame"
                 android:layout_width="100dp"
                 android:layout_height="100dp"
-                android:layout_marginBottom="20dp"
-                android:layout_marginTop="30dp"
                 android:layout_marginStart="50dp"
-                app:layout_constraintTop_toBottomOf="@id/cl_check_no_expense"
-                app:layout_constraintStart_toEndOf="@id/tv_expense_photo">
+                android:layout_marginTop="30dp"
+                android:layout_marginBottom="20dp"
+                app:layout_constraintStart_toEndOf="@id/tv_expense_photo"
+                app:layout_constraintTop_toBottomOf="@id/cl_check_no_expense">
 
                 <ImageView
                     android:id="@+id/img_photo_frame"
                     android:layout_width="100dp"
                     android:layout_height="100dp"
-                    android:src="@drawable/bg_photo_input"/>
+                    android:src="@drawable/bg_photo_input" />
 
                 <ImageView
                     android:id="@+id/iv_photo_icon"
@@ -413,62 +414,6 @@
                     android:src="@drawable/ic_photo_input" />
 
             </FrameLayout>
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/cl_expense_auto"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="30dp"
-                android:layout_marginBottom="30dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/fl_photo_frame"
-                app:layout_constraintBottom_toBottomOf="parent"
-                android:visibility="gone">
-
-                <ImageView
-                    android:id="@+id/iv_circle_send_auto_unchecked"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/ic_radio_unchecked"
-                    android:layout_marginTop="5dp"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"/>
-
-                <ImageView
-                    android:id="@+id/iv_circle_send_auto_checked"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/ic_radio_checked"
-                    android:layout_marginTop="5dp"
-                    android:visibility="invisible"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"/>
-
-                <TextView
-                    android:id="@+id/tv_auto_send_chat"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="채팅방에 지출 내역 자동 전송"
-                    android:textSize="15sp"
-                    android:layout_marginStart="8dp"
-                    style="@style/body_regula"
-                    android:textColor="@color/black"
-                    app:layout_constraintStart_toEndOf="@id/iv_circle_send_auto_unchecked"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <TextView
-                    android:id="@+id/tv_auto_send_chat_detail"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="가입한 챌린지 그룹 채팅방에 지출 내역을 자동 전송돼요."
-                    android:textColor="@color/black2"
-                    android:textSize="12sp"
-                    android:layout_marginTop="4dp"
-                    app:layout_constraintTop_toBottomOf="@id/tv_auto_send_chat"
-                    app:layout_constraintStart_toStartOf="@id/tv_auto_send_chat"/>
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
## *📌 Issue*
- closed #89 
<!-- closed를 붙이면 해당 이슈가 PR과 함께 자동으로 close -->

## *⛳️ Work Description*
- 지출 내역, 수정 페이지에 첨부한 사진 보이기


## *📸 Screenshot*
<!-- 실행 사진이나 영상을 
드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->
https://github.com/user-attachments/assets/63d04039-8570-4b5f-85be-43e7d1de7f55


## *📢 To Reviewers*
- 사진이 쥐똥만하게 보이는 건 내일 오후 중으로 수정하겠습니다..
- 다른 날짜로 수정해서 저장하면 지출기입 월간페이지로 이동 기능은 지금 튕기는 오류가 있는 것 같습니다. 이것도 내일 오후 중으로 수정할게요..


<!-- PR 제목 형식: [FEATURE/#이슈번호] 작업 주제 -->
